### PR TITLE
Fix/47352

### DIFF
--- a/src/SME.SGP.WebClient/src/componentes/jodit-editor/joditEditor.js
+++ b/src/SME.SGP.WebClient/src/componentes/jodit-editor/joditEditor.js
@@ -42,6 +42,7 @@ const JoditEditor = forwardRef((props, ref) => {
     permiteVideo,
     qtdMaxImg,
     imagensCentralizadas,
+    valideClipboardHTML,
   } = props;
 
   const textArea = useRef(null);
@@ -93,6 +94,7 @@ const JoditEditor = forwardRef((props, ref) => {
         }
       },
     },
+    askBeforePasteHTML: valideClipboardHTML,
     disablePlugins: ['image-properties', 'inline-popup'],
     language: 'pt_br',
     height,
@@ -397,6 +399,7 @@ JoditEditor.propTypes = {
   permiteVideo: PropTypes.bool,
   qtdMaxImg: PropTypes.number,
   imagensCentralizadas: PropTypes.bool,
+  valideClipboardHTML: PropTypes.bool,
 };
 
 JoditEditor.defaultProps = {
@@ -419,6 +422,7 @@ JoditEditor.defaultProps = {
   permiteVideo: true,
   qtdMaxImg: null,
   imagensCentralizadas: false,
+  valideClipboardHTML: true,
 };
 
 export default JoditEditor;

--- a/src/SME.SGP.WebClient/src/paginas/DiarioClasse/DiarioBordo/diarioBordo.js
+++ b/src/SME.SGP.WebClient/src/paginas/DiarioClasse/DiarioBordo/diarioBordo.js
@@ -677,6 +677,7 @@ const DiarioBordo = ({ match }) => {
                             key="1"
                           >
                             <JoditEditor
+                              valideClipboardHTML={false}
                               form={form}
                               value={form.values.planejamento}
                               name="planejamento"
@@ -699,6 +700,7 @@ const DiarioBordo = ({ match }) => {
                             key="2"
                           >
                             <JoditEditor
+                              valideClipboardHTML={false}
                               form={form}
                               value={form.values.reflexoesReplanejamento}
                               name="reflexoesReplanejamento"
@@ -720,6 +722,7 @@ const DiarioBordo = ({ match }) => {
                           <PainelCollapse.Painel temBorda header="Devolutivas">
                             {form && form.values && form.values.devolutivas ? (
                               <JoditEditor
+                                valideClipboardHTML={false}
                                 label="Somente leitura"
                                 form={form}
                                 value={form.values.devolutivas}


### PR DESCRIPTION
[AB#47352](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/47352)

Possibilidade de não exibir mensagem questionando usuário sobre o tipo de texto que está sendo colado no input