### PR TITLE
Correção do bug 61173

### DIFF
--- a/src/SME.SGP.WebClient/src/componentes-sgp/ObservacoesUsuario/campoObservacao.js
+++ b/src/SME.SGP.WebClient/src/componentes-sgp/ObservacoesUsuario/campoObservacao.js
@@ -121,7 +121,7 @@ const CampoObservacao = props => {
           autoSize={{ minRows: 4 }}
           value={novaObservacao}
           onChange={onChangeNovaObservacao}
-          disabled={!!observacaoEmEdicao || !podeIncluir || !!diarioBordoId}
+          disabled={!!observacaoEmEdicao || !podeIncluir}
         />
       </div>
       <div

--- a/src/SME.SGP.WebClient/src/paginas/Fechamento/FechamentoBimestre/fechamanto-regencia/fechamento-regencia.js
+++ b/src/SME.SGP.WebClient/src/paginas/Fechamento/FechamentoBimestre/fechamanto-regencia/fechamento-regencia.js
@@ -11,10 +11,10 @@ import ServicoFechamentoBimestre from '~/servicos/Paginas/Fechamento/ServicoFech
 import { MarcadorTriangulo } from '~/componentes';
 
 const FechamentoRegencia = props => {
-  const { idRegencia, dados } = props;
+  const { idRegencia, dados, refElement } = props;
 
   return (
-    <TrRegencia id={idRegencia} style={{ display: 'none' }}>
+    <TrRegencia id={idRegencia} ref={refElement} style={{ display: 'none' }}>
       <td colSpan="2" className="destaque-label">
         Conceitos finais regência de classe
       </td>

--- a/src/SME.SGP.WebClient/src/paginas/Fechamento/FechamentoBimestre/fechamento-bimestre-lista/botao-expandir.js
+++ b/src/SME.SGP.WebClient/src/paginas/Fechamento/FechamentoBimestre/fechamento-bimestre-lista/botao-expandir.js
@@ -2,15 +2,14 @@ import React, { useState } from 'react';
 import { MaisMenos } from './fechamento-bimestre-lista.css';
 
 const BotaoExpandir = props => {
-  const { index, idLinhaRegencia } = props;
+  const { index, idLinhaRegencia, refElement } = props;
   const [expandido, setExpandido] = useState(false);
 
   const clickExpandirRetrair = () => {
     setExpandido(!expandido);
-    const linhaRegencia = window.document.getElementById(idLinhaRegencia);
-    if (linhaRegencia) {
-      const display = linhaRegencia.style.display;
-      linhaRegencia.style.display = display === 'none' ? 'contents' : 'none';
+    if (refElement) {
+      refElement.current.style.display =
+      refElement.current.style.display === 'none' ? 'contents' : 'none';
     }
   };
 

--- a/src/SME.SGP.WebClient/src/paginas/Fechamento/FechamentoBimestre/fechamento-bimestre-lista/fechamento-bimestre-lista.js
+++ b/src/SME.SGP.WebClient/src/paginas/Fechamento/FechamentoBimestre/fechamento-bimestre-lista/fechamento-bimestre-lista.js
@@ -271,6 +271,8 @@ const FechamentoBimestreLista = props => {
             {dadosLista && dadosLista.length > 0 ? (
               dadosLista.map((item, index) => {
                 const idLinhaRegencia = `fechamento-regencia-${index}`;
+                const refLinhaRegencia = React.createRef();
+
                 return (
                   <>
                     <tr>
@@ -338,6 +340,7 @@ const FechamentoBimestreLista = props => {
                           <BotaoExpandir
                             index={index}
                             idLinhaRegencia={idLinhaRegencia}
+                            refElement={refLinhaRegencia}
                           />
                         ) : item.notas && item.notas.length > 0 ? (
                           item.notas[0].ehConceito ? (
@@ -386,6 +389,7 @@ const FechamentoBimestreLista = props => {
                       <FechamentoRegencia
                         dados={item.notas}
                         idRegencia={`fechamento-regencia-${index}`}
+                        refElement={refLinhaRegencia}
                       />
                     ) : null}
                   </>


### PR DESCRIPTION
Retirada a condição para habilitar o campo observações caso o id do diário de bordo não esteja preenchido, como para casos em que o mesmo campo é utilizado. A verificação da permissão para editar o campo já é feita no backend.