### PR TITLE
Correção do bug 61173

### DIFF
--- a/src/SME.SGP.WebClient/src/componentes-sgp/ObservacoesUsuario/campoObservacao.js
+++ b/src/SME.SGP.WebClient/src/componentes-sgp/ObservacoesUsuario/campoObservacao.js
@@ -121,7 +121,7 @@ const CampoObservacao = props => {
           autoSize={{ minRows: 4 }}
           value={novaObservacao}
           onChange={onChangeNovaObservacao}
-          disabled={!!observacaoEmEdicao || !podeIncluir || !!diarioBordoId}
+          disabled={!!observacaoEmEdicao || !podeIncluir}
         />
       </div>
       <div


### PR DESCRIPTION
[AB#61173](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/61173)

Retirada a condição para habilitar o campo observações caso o id do diário de bordo não esteja preenchido, como para casos em que o mesmo campo é utilizado. A verificação da permissão para editar o campo já é feita no backend.