### PR TITLE
fix 71054 - Calendário escolar - usar anoLetivo do calendário e não do ano atual …

### DIFF
--- a/src/SME.SGP.WebClient/src/componentes-sgp/calendarioEscolar/MesCompleto.js
+++ b/src/SME.SGP.WebClient/src/componentes-sgp/calendarioEscolar/MesCompleto.js
@@ -38,6 +38,7 @@ const MesCompleto = props => {
     eventoSme,
     dreSelecionada,
     unidadeEscolarSelecionada,
+    anoLetivo,
   } = filtros;
 
   const mesesLista = meses.split(',');
@@ -120,9 +121,8 @@ const MesCompleto = props => {
   );
 
   useEffect(() => {
-    if (mesSelecionado > 0) {
-      const dataAtual = new Date();
-      const data = new Date(dataAtual.getFullYear(), mesSelecionado - 1, 1);
+    if (mesSelecionado > 0 && anoLetivo) {
+      const data = new Date(anoLetivo, mesSelecionado - 1, 1);
       data.setDate(data.getDate() - data.getDay() - 1);
 
       const diasDaSemanaLista = [];


### PR DESCRIPTION
…para montar o mês completo [AB#71054](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/71054)