### PR TITLE
Remove opção Todos da seleção de Dres ao gerar relatório de frequência

### DIFF
--- a/src/@legacy/paginas/Gestao/AtribuicaoSupervisor/atribuicaoSupervisorLista.js
+++ b/src/@legacy/paginas/Gestao/AtribuicaoSupervisor/atribuicaoSupervisorLista.js
@@ -89,7 +89,7 @@ export default function AtribuicaoSupervisorLista() {
       width: '20%',
       render: text => {
         return (
-          text || <span className="texto-vermelho-negrito">NÃO ATRIBUIDO</span>
+          text || <span className="texto-vermelho-negrito">NÃO ATRIBUÍDO</span>
         );
       },
     },
@@ -99,7 +99,7 @@ export default function AtribuicaoSupervisorLista() {
       width: '35%',
       render: text => {
         return (
-          text || <span className="texto-vermelho-negrito">NÃO ATRIBUIDO</span>
+          text || <span className="texto-vermelho-negrito">NÃO ATRIBUÍDO</span>
         );
       },
     },

--- a/src/@legacy/paginas/Relatorios/Frequencia/relatorioFrequencia.js
+++ b/src/@legacy/paginas/Relatorios/Frequencia/relatorioFrequencia.js
@@ -236,11 +236,6 @@ const RelatorioFrequencia = () => {
 
       if (lista?.length === 1) {
         setCodigoDre(lista[0].valor);
-      } else {
-        lista.unshift({
-          desc: 'Todas',
-          valor: OPCAO_TODOS,
-        });
       }
 
       setListaDres(lista);
@@ -715,18 +710,23 @@ const RelatorioFrequencia = () => {
     setModoEdicao(true);
   };
 
+  const setTodosParaTurma = useCallback((codigoUe) => {
+    if (codigoUe === OPCAO_TODOS) {
+      const OPCAO_TODAS_TURMA = { valor: OPCAO_TODOS, nomeFiltro: 'Todas' };
+      setListaTurmas([OPCAO_TODAS_TURMA]);
+      setTurmasCodigo([OPCAO_TODAS_TURMA.valor]);
+      return true;
+    }
+    return false;
+  }, []);
+
   const obterTurmas = useCallback(
     async (modalidadeSelecionada, ue, ano, semestreSelecionado, ehEja) => {
       if (ue && modalidadeSelecionada) {
         const OPCAO_TODAS_TURMA = { valor: OPCAO_TODOS, nomeFiltro: 'Todas' };
 
         if (ehEja && !semestreSelecionado) return;
-
-        if (ue === OPCAO_TODOS) {
-          setListaTurmas([OPCAO_TODAS_TURMA]);
-          setTurmasCodigo([OPCAO_TODAS_TURMA.valor]);
-          return;
-        }
+        if (setTodosParaTurma(ue)) return;
 
         setCarregandoTurmas(true);
         const { data } = await AbrangenciaServico.buscarTurmas(
@@ -775,9 +775,7 @@ const RelatorioFrequencia = () => {
       setFormato(FORMATOS.PDF);
       setTurmasPrograma(true);
 
-      if (codigoUe === OPCAO_TODOS) {
-        setTurmasCodigo(OPCAO_TODOS);
-      }
+      setTodosParaTurma(codigoUe);
       return;
     }
     setTurmasCodigo(undefined);


### PR DESCRIPTION
Corrige a acentuação da palavra 'ATRIBUÍDO' em atribuicaoSupervisorLista.js. No relatorioFrequencia.js, refatora a lógica de seleção de todas as turmas ao encapsular o comportamento em uma função utilitária, melhorando a clareza e reutilização do código.